### PR TITLE
Updates to GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,16 +11,16 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x]
+        platform: [ubuntu-latest, macos-latest, windows-latest, macos-14]
     runs-on: ${{ matrix.platform }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
     - name: Install Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v3
     - name: Test
       run: |
         go version


### PR DESCRIPTION
- Support for testing with go1.22
- Support for testing with Apple M1 platform
- Update CI actions
- Fixed the order of actions, doing checkout first will allow `setup-go` to effectively use cache.